### PR TITLE
让组合管理模板支持在RPC环境中运行

### DIFF
--- a/vnpy_portfoliomanager/base.py
+++ b/vnpy_portfoliomanager/base.py
@@ -1,10 +1,7 @@
-from typing import Dict, List, TYPE_CHECKING, Optional
+from typing import Dict, List, Optional
 
 from vnpy.trader.object import TickData, TradeData, ContractData
 from vnpy.trader.constant import Direction
-
-if TYPE_CHECKING:
-    from .engine import PortfolioEngine
 
 
 class ContractResult:
@@ -12,7 +9,8 @@ class ContractResult:
 
     def __init__(
         self,
-        engine: "PortfolioEngine",
+        contract: ContractData,
+        tick: TickData,
         reference: str,
         vt_symbol: str,
         open_pos: int = 0
@@ -20,7 +18,8 @@ class ContractResult:
         """"""
         super().__init__()
 
-        self.engine: "PortfolioEngine" = engine
+        self.contract: Optional[ContractData] = contract
+        self.tick: Optional[TickData] = tick
 
         self.reference: str = reference
         self.vt_symbol: str = vt_symbol
@@ -55,15 +54,11 @@ class ContractResult:
 
     def calculate_pnl(self) -> None:
         """"""
-        vt_symbol: str = self.vt_symbol
-
-        contract: Optional[ContractData] = self.engine.get_contract(vt_symbol)
-        tick: Optional[TickData] = self.engine.get_tick(vt_symbol)
-        if not contract or not tick:
+        if not self.contract or not self.tick:
             return
 
-        last_price: float = tick.last_price
-        size: float = contract.size
+        last_price: float = self.tick.last_price
+        size: float = self.contract.size
 
         # 计算新成交额
         for trade in self.new_trades:
@@ -89,7 +84,8 @@ class ContractResult:
         self.trading_pnl = long_pnl + short_pnl
 
         # 计算未实现利润和总利润
-        self.holding_pnl = (last_price - tick.pre_close) * self.open_pos * size
+        self.holding_pnl = (
+            last_price - self.tick.pre_close) * self.open_pos * size
         self.total_pnl = self.holding_pnl + self.trading_pnl
 
 

--- a/vnpy_portfoliomanager/engine.py
+++ b/vnpy_portfoliomanager/engine.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, Set, Optional
 from datetime import datetime
+from copy import copy
 
 from vnpy.event import Event
 from vnpy.trader.engine import (
@@ -86,26 +87,30 @@ class PortfolioEngine(BaseEngine):
         vt_symbol: str = trade.vt_symbol
         key: set = (reference, vt_symbol)
 
-        contract_result: Optional[ContractResult] = self.contract_results.get(key, None)
+        contract_result: Optional[ContractResult] = self.contract_results.get(
+            key, None)
         if not contract_result:
-            contract_result: ContractResult = ContractResult(self, reference, vt_symbol)
+            contract_result: ContractResult = ContractResult(self.get_contract(
+                vt_symbol), self.get_tick(vt_symbol), reference, vt_symbol)
             self.contract_results[key] = contract_result
 
         contract_result.update_trade(trade)
 
         # 添加成交数据
         trade.reference = reference
-        self.event_engine.put(Event(EVENT_PM_TRADE, trade))
+        self.event_engine.put(Event(EVENT_PM_TRADE, copy(trade)))
 
         # 自动订阅tick数据
         if trade.vt_symbol in self.subscribed:
             return
 
-        contract: Optional[ContractData] = self.main_engine.get_contract(trade.vt_symbol)
+        contract: Optional[ContractData] = self.main_engine.get_contract(
+            trade.vt_symbol)
         if not contract:
             return
 
-        req: SubscribeRequest = SubscribeRequest(contract.symbol, contract.exchange)
+        req: SubscribeRequest = SubscribeRequest(
+            contract.symbol, contract.exchange)
         self.main_engine.subscribe(req, contract.gateway_name)
 
     def process_timer_event(self, event: Event) -> None:
@@ -121,16 +126,17 @@ class PortfolioEngine(BaseEngine):
         for contract_result in self.contract_results.values():
             contract_result.calculate_pnl()
 
-            portfolio_result: PortfolioResult = self.get_portfolio_result(contract_result.reference)
+            portfolio_result: PortfolioResult = self.get_portfolio_result(
+                contract_result.reference)
             portfolio_result.trading_pnl += contract_result.trading_pnl
             portfolio_result.holding_pnl += contract_result.holding_pnl
             portfolio_result.total_pnl += contract_result.total_pnl
 
-            event: Event = Event(EVENT_PM_CONTRACT, contract_result)
+            event: Event = Event(EVENT_PM_CONTRACT, copy(contract_result))
             self.event_engine.put(event)
 
         for portfolio_result in self.portfolio_results.values():
-            event: Event = Event(EVENT_PM_PORTFOLIO, portfolio_result)
+            event: Event = Event(EVENT_PM_PORTFOLIO, copy(portfolio_result))
             self.event_engine.put(event)
 
     def process_contract_event(self, event: Event) -> None:
@@ -139,7 +145,8 @@ class PortfolioEngine(BaseEngine):
         if contract.vt_symbol not in self.result_symbols:
             return
 
-        req: SubscribeRequest = SubscribeRequest(contract.symbol, contract.exchange)
+        req: SubscribeRequest = SubscribeRequest(
+            contract.symbol, contract.exchange)
         self.main_engine.subscribe(req, contract.gateway_name)
 
         self.subscribed.add(contract.vt_symbol)
@@ -165,7 +172,8 @@ class PortfolioEngine(BaseEngine):
 
             self.result_symbols.add(vt_symbol)
             self.contract_results[(reference, vt_symbol)] = ContractResult(
-                self,
+                self.get_contract(vt_symbol),
+                self.get_tick(vt_symbol),
                 reference,
                 vt_symbol,
                 pos
@@ -224,7 +232,8 @@ class PortfolioEngine(BaseEngine):
 
     def get_portfolio_result(self, reference: str) -> PortfolioResult:
         """"""
-        portfolio_result: Optional[PortfolioResult] = self.portfolio_results.get(reference, None)
+        portfolio_result: Optional[PortfolioResult] = self.portfolio_results.get(
+            reference, None)
         if not portfolio_result:
             portfolio_result = PortfolioResult(reference)
             self.portfolio_results[reference] = portfolio_result


### PR DESCRIPTION
如果组合管理模块与RPC模块一块运行，则报错```TypeError: can't pickle _thread.lock objects```。经过检查，是由于组合管理模块把ContractResult对象put到event中导致的，而ContracResult对象是复杂类型，含有engine的引用。

修改方法：在构建ContractResult的地方，用engine获取ContractResult所需的tick以及contract即可，把ContractResult作为纯数据的实例，即可在多线程环境下安全地传输。